### PR TITLE
Add music reactive acid smiley demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# paul
+# Acid Interface Demo
+
+This repository contains a simple web interface featuring an animated "acid" smiley that reacts to audio input. Select an audio file of your choice and watch the smiley pulse to the beat.
+
+## Usage
+
+Open `index.html` in a modern browser. Use the file picker to load an audio file (e.g., MP3 or WAV) and press play. The smiley will scale based on the music's volume.
+
+No external dependencies are required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Acid Interface</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Acid Interface</h1>
+<div id="controls">
+  <input type="file" id="audioFile" accept="audio/*">
+  <audio id="audio" controls></audio>
+</div>
+<div id="smiley">
+  <div class="mouth"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,43 @@
+const fileInput = document.getElementById('audioFile');
+const audioEl = document.getElementById('audio');
+const smiley = document.getElementById('smiley');
+
+let audioContext, analyser, source;
+
+fileInput.addEventListener('change', () => {
+  const file = fileInput.files[0];
+  if (!file) return;
+  const url = URL.createObjectURL(file);
+  audioEl.src = url;
+  audioEl.play();
+  setupAudio();
+});
+
+function setupAudio() {
+  if (audioContext) return;
+  audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  source = audioContext.createMediaElementSource(audioEl);
+  analyser = audioContext.createAnalyser();
+  analyser.fftSize = 256;
+  source.connect(analyser);
+  analyser.connect(audioContext.destination);
+  animate();
+}
+
+function getAmplitude() {
+  const data = new Uint8Array(analyser.frequencyBinCount);
+  analyser.getByteFrequencyData(data);
+  let sum = 0;
+  for (let i = 0; i < data.length; i++) {
+    sum += data[i];
+  }
+  return sum / data.length / 255; // 0..1
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  if (!analyser) return;
+  const amp = getAmplitude();
+  const scale = 1 + amp * 0.5;
+  smiley.style.transform = `scale(${scale})`;
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,54 @@
+body {
+  background: black;
+  color: #0f0;
+  font-family: Arial, Helvetica, sans-serif;
+  text-align: center;
+}
+
+#controls {
+  margin: 20px;
+}
+
+#smiley {
+  width: 200px;
+  height: 200px;
+  margin: 40px auto;
+  border-radius: 50%;
+  background: yellow;
+  position: relative;
+  box-shadow: 0 0 30px #f0f;
+  transform: scale(1);
+  transition: transform 0.1s linear;
+}
+
+#smiley::before,
+#smiley::after {
+  content: '';
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  top: 60px;
+  background: black;
+  border-radius: 50%;
+}
+
+#smiley::before {
+  left: 40px;
+}
+
+#smiley::after {
+  right: 40px;
+}
+
+#smiley .mouth {
+  position: absolute;
+  bottom: 50px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 60px;
+  border: 10px solid black;
+  border-top: none;
+  border-radius: 0 0 60px 60px;
+}
+


### PR DESCRIPTION
## Summary
- add a colorful index page with an audio file picker
- style the page with neon colors and a smiley face
- animate the smiley in JavaScript based on audio volume
- update README with instructions

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842e00957a483229bd1872705c136d5